### PR TITLE
Fix self-play results logging format

### DIFF
--- a/tests/test_selfplay.cpp
+++ b/tests/test_selfplay.cpp
@@ -1,5 +1,10 @@
 #include <gtest/gtest.h>
 
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
 #include "training/selfplay.h"
 
 namespace chiron {
@@ -17,6 +22,45 @@ TEST(SelfPlay, GeneratesGameData) {
     SelfPlayResult result = orchestrator.play_game(0, config.white, config.black, false);
     EXPECT_GE(result.ply_count, 0);
     EXPECT_FALSE(result.result.empty());
+}
+
+TEST(SelfPlay, LogsWellFormedResultLine) {
+    namespace fs = std::filesystem;
+
+    auto timestamp = std::chrono::steady_clock::now().time_since_epoch().count();
+    fs::path temp_file = fs::temp_directory_path() /
+                        fs::path("selfplay-log-" + std::to_string(timestamp) + ".jsonl");
+
+    SelfPlayConfig config;
+    config.games = 1;
+    config.white.max_depth = 1;
+    config.black.max_depth = 1;
+    config.capture_results = true;
+    config.capture_pgn = false;
+    config.append_logs = false;
+    config.results_log = temp_file.string();
+    config.max_ply = 40;
+
+    SelfPlayOrchestrator orchestrator(config);
+    orchestrator.play_game(0, config.white, config.black, true);
+
+    std::ifstream log_stream(temp_file);
+    ASSERT_TRUE(log_stream.is_open());
+
+    std::string line;
+    std::getline(log_stream, line);
+    log_stream.close();
+    fs::remove(temp_file);
+
+    ASSERT_FALSE(line.empty());
+    EXPECT_EQ(line.front(), '{');
+    EXPECT_EQ(line.back(), '}');
+
+    auto white_pos = line.find("\"white\":\"");
+    ASSERT_NE(white_pos, std::string::npos);
+    EXPECT_EQ(line.find("\"white\":\"", white_pos + 1), std::string::npos);
+
+    EXPECT_EQ(line.find(",\"\""), std::string::npos);
 }
 
 }  // namespace chiron

--- a/training/selfplay.cpp
+++ b/training/selfplay.cpp
@@ -357,14 +357,14 @@ void SelfPlayOrchestrator::log_result(int game_index, const SelfPlayResult& resu
     }
     results_stream_ << '{';
     results_stream_ << "\"game\":" << (game_index + 1) << ',';
-    results_stream_ << "\"white\":\"" << escape_json(result.white_player) << "\",\"";
-    results_stream_ << "\"black\":\"" << escape_json(result.black_player) << "\",\"";
-    results_stream_ << "\"result\":\"" << escape_json(result.result) << "\",\"";
-    results_stream_ << "\"termination\":\"" << escape_json(result.termination) << "\",\"";
+    results_stream_ << "\"white\":\"" << escape_json(result.white_player) << "\",";
+    results_stream_ << "\"black\":\"" << escape_json(result.black_player) << "\",";
+    results_stream_ << "\"result\":\"" << escape_json(result.result) << "\",";
+    results_stream_ << "\"termination\":\"" << escape_json(result.termination) << "\",";
     results_stream_ << "\"ply_count\":" << result.ply_count << ',';
     results_stream_ << "\"duration_ms\":" << std::fixed << std::setprecision(2) << result.duration_ms << ',';
-    results_stream_ << "\"start_fen\":\"" << escape_json(result.start_fen) << "\",\"";
-    results_stream_ << "\"end_fen\":\"" << escape_json(result.end_fen) << "\",\"";
+    results_stream_ << "\"start_fen\":\"" << escape_json(result.start_fen) << "\",";
+    results_stream_ << "\"end_fen\":\"" << escape_json(result.end_fen) << "\",";
     results_stream_ << "\"moves\":" << join_string_array(result.moves_san);
     if (config_.record_fens) {
         results_stream_ << ",\"fens\":" << join_string_array(result.fens);


### PR DESCRIPTION
## Summary
- add a self-play test that captures the results log output and verifies the JSON formatting
- correct the orchestrator's JSON logging to avoid emitting stray quotes between fields

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_b_68d2a72fe484832d913126af5d5b4bfb