### PR TITLE
Improve self-play stability and training persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,10 @@
 
 # debug information files
 *.dwo
+
+# Build trees and generated artefacts
+build/
+*.jsonl
+*.pgn
+*.nnue
+nnue/models/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,9 +2,9 @@
 
 #include <algorithm>
 #include <exception>
-#include <algorithm>
 #include <filesystem>
 #include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <random>
 #include <stdexcept>
@@ -168,6 +168,9 @@ int run_selfplay(const std::vector<std::string>& args) {
         } else if (opt == "--training-output") {
             if (i + 1 >= args.size()) throw std::invalid_argument(opt + " requires a value");
             config.training_output_path = args[++i];
+        } else if (opt == "--training-history") {
+            if (i + 1 >= args.size()) throw std::invalid_argument(opt + " requires a value");
+            config.training_history_dir = args[++i];
         } else {
             throw std::invalid_argument("Unknown selfplay option: " + opt);
         }
@@ -252,6 +255,13 @@ int run_sprt(const std::vector<std::string>& args) {
     std::cout << "Games: " << summary.games_played << ", candidate wins: " << summary.candidate_wins
               << ", baseline wins: " << summary.baseline_wins << ", draws: " << summary.draws << "\n";
     std::cout << "LLR: " << summary.llr << "\n";
+    if (summary.elo) {
+        std::cout << "Estimated Elo: " << std::fixed << std::setprecision(2) << *summary.elo;
+        if (summary.elo_confidence) {
+            std::cout << " ±" << *summary.elo_confidence;
+        }
+        std::cout << std::defaultfloat << std::setprecision(6) << "\n";
+    }
     return 0;
 }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -611,8 +611,9 @@ std::vector<Move> Search::extract_pv(Board& board) const {
     std::vector<Board::State> states;
     states.reserve(64);
     for (int depth = 0; depth < 64; ++depth) {
-        const TTEntry& entry = entry_for_key(copy.zobrist_key());
-        if (entry.flag == static_cast<std::uint8_t>(TTFlag::Empty)) {
+        std::uint64_t key = copy.zobrist_key();
+        const TTEntry& entry = entry_for_key(key);
+        if (entry.flag == static_cast<std::uint8_t>(TTFlag::Empty) || entry.key != key) {
             break;
         }
         Move move = entry.move;

--- a/tools/tuning.cpp
+++ b/tools/tuning.cpp
@@ -126,6 +126,17 @@ SprtSummary SprtTester::run() {
     summary.baseline_wins = baseline_wins_;
     summary.draws = draws_;
 
+    double wins = static_cast<double>(candidate_wins_) + 0.5 * static_cast<double>(draws_);
+    double losses = static_cast<double>(baseline_wins_) + 0.5 * static_cast<double>(draws_);
+    if (wins > 0.0 && losses > 0.0) {
+        double ratio = wins / losses;
+        double elo = 400.0 * std::log10(ratio);
+        double variance = (1.0 / wins) + (1.0 / losses);
+        double sigma = (400.0 / std::log(10.0)) * std::sqrt(variance);
+        summary.elo = elo;
+        summary.elo_confidence = 1.96 * sigma;
+    }
+
     if (log_stream) {
         log_stream.flush();
     }

--- a/tools/tuning.h
+++ b/tools/tuning.h
@@ -2,6 +2,7 @@
 
 #include <fstream>
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "tools/time_manager.h"
@@ -26,6 +27,8 @@ struct SprtSummary {
     int candidate_wins = 0;
     int baseline_wins = 0;
     int draws = 0;
+    std::optional<double> elo;
+    std::optional<double> elo_confidence;
 };
 
 class SprtTester {

--- a/training/selfplay.h
+++ b/training/selfplay.h
@@ -39,7 +39,8 @@ struct SelfPlayConfig {
     bool enable_training = false;
     std::size_t training_batch_size = 256;
     double training_learning_rate = 0.05;
-    std::string training_output_path = "trained.nnue";
+    std::string training_output_path = "nnue/models/chiron-selfplay-latest.nnue";
+    std::string training_history_dir = "nnue/models/history";
 };
 
 struct SelfPlayResult {
@@ -79,6 +80,11 @@ class SelfPlayOrchestrator {
     Trainer trainer_;
     ParameterSet parameters_;
     std::vector<TrainingExample> training_buffer_;
+    int training_iteration_ = 0;
+    std::string training_history_prefix_;
+    std::string training_history_extension_;
+
+    int detect_existing_history_iteration() const;
 };
 
 }  // namespace chiron


### PR DESCRIPTION
## Summary
- guard transposition-table PV extraction by verifying stored keys before using cached moves
- extend self-play training to default to nnue/models storage, auto-create directories, and archive per-step snapshots with a new --training-history option
- surface Elo estimates from tune sprt, update documentation for Windows/macOS builds and model storage, and ignore generated artifacts

## Testing
- ctest --test-dir build
- ./build/chiron selfplay --games 2 --concurrency 1 --depth 4 --no-results --no-pgn
- ./build/chiron selfplay --games 1 --concurrency 1 --depth 4 --enable-training --training-batch 1 --training-output nnue/models/test-latest.nnue --training-history nnue/models/test-history --no-results --no-pgn


------
https://chatgpt.com/codex/tasks/task_b_68d3d0e3bfd8832dbb63dab241ab2a24