### PR TITLE
Add verbose self-play telemetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,10 @@
 
 # debug information files
 *.dwo
+
+# Build trees and generated artefacts
+build/
+*.jsonl
+*.pgn
+*.nnue
+nnue/models/

--- a/README.md
+++ b/README.md
@@ -26,7 +26,27 @@ cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build --config Release
 ```
 
-On Windows with MSVC, run the commands from a Developer Command Prompt. Replace `Release` with `Debug` as required.
+#### Windows (Visual Studio 2022)
+
+Open a **Developer Command Prompt for VS 2022** and generate the solution explicitly:
+
+```bash
+cmake -S . -B build -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release
+cmake --build build --config Release
+```
+
+You can open the resulting solution in Visual Studio or let the VS Code CMake Tools extension drive the build.
+
+#### macOS (Apple Silicon)
+
+Install the Xcode Command Line Tools (`xcode-select --install`) and ensure recent CMake binaries are available (e.g. `brew install cmake ninja`). Build a native arm64 binary with:
+
+```bash
+cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=arm64
+ninja -C build
+```
+
+These presets work seamlessly inside VS Code's integrated terminal on macOS.
 
 ### Running Tests
 
@@ -69,6 +89,19 @@ The `chiron` executable also exposes a suite of helper commands:
 | `teacher --engine /path/to/uci --positions fens.txt [--output labels.txt] [--depth 20] [--threads 4]` | Calls an external UCI engine to annotate positions with evaluations. |
 | `tune sprt ...` / `tune time ...` | Existing tuning utilities for SPRT matches and time-heuristic analysis. |
 
+## Measuring Playing Strength
+
+Use the SPRT harness to compare two binaries or network revisions and obtain an Elo estimate with confidence bounds:
+
+```bash
+./chiron tune sprt --games 400 --elo0 0 --elo1 20 \
+  --baseline-name Baseline --candidate-name Candidate \
+  --baseline-network nnue/models/baseline.nnue \
+  --candidate-network nnue/models/chiron-selfplay-latest.nnue
+```
+
+The summary reports the SPRT conclusion, win/draw statistics, and the estimated Elo difference ± one 95% confidence interval, making it easy to track progress toward ambitious rating targets (3000+ Elo).
+
 ## Self-Play and Training
 
 Launch concurrent self-play with optional training:
@@ -81,7 +114,8 @@ Launch concurrent self-play with optional training:
   --enable-training \
   --training-batch 512 \
   --training-rate 0.05 \
-  --training-output trained.nnue \
+  --training-output nnue/models/chiron-selfplay-latest.nnue \
+  --training-history nnue/models/history \
   --results results.jsonl \
   --pgn games.pgn
 ```
@@ -93,9 +127,19 @@ Key options:
 * `--enable-training` – Collect FENs and periodically update the evaluator.
 * `--training-batch SIZE` – Number of samples per optimisation step.
 * `--training-rate RATE` – Learning rate for the internal trainer.
-* `--training-output PATH` – Where to store updated NNUE weights.
+* `--training-output PATH` – Where to store the continually updated NNUE weights.
+* `--training-history DIR` – Optional directory for archiving per-step snapshots.
+* `--verbose` – Print per-move search telemetry and training updates during self-play.
 
 Training batches are accumulated from every game (start position plus subsequent FENs). When the buffer exceeds the requested batch size, the trainer performs an optimisation step, saves the updated network, and reloads it for subsequent games.
+
+### Verbose Telemetry
+
+Enable `--verbose` to monitor self-play in real time. Each move is reported with its SAN notation, search depth/seldepth, evaluation (centipawns or mate score), node counts, NPS, elapsed time, and the current principal variation—useful insight for chess programmers inspecting move ordering and search stability. After every game, and whenever the training buffer flushes, verbose mode also prints how many positions were collected, the running totals processed, and where updated NNUE weights and history snapshots were written, giving AI practitioners clear feedback on dataset growth and model iteration cadence.
+
+### Model Storage
+
+By default the latest self-play network is written to `nnue/models/chiron-selfplay-latest.nnue`. Each optimisation step also writes a snapshot to `nnue/models/history/<prefix>-iterXXXX.nnue`. Both paths are configurable via `--training-output` and `--training-history`, and required directories are created automatically on Windows, macOS, and Linux.
 
 ## Dataset & Teacher Workflow
 

--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -4,7 +4,10 @@
 
 namespace chiron {
 
-std::ostream& operator<<(std::ostream& os, Bitboard b) {
+BitboardPretty pretty(Bitboard b) { return BitboardPretty{b}; }
+
+std::ostream& operator<<(std::ostream& os, BitboardPretty pretty) {
+    Bitboard b = pretty.value;
     for (int rank = 7; rank >= 0; --rank) {
         os << rank + 1 << " ";
         for (int file = 0; file < 8; ++file) {

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -112,9 +112,21 @@ constexpr inline Bitboard south_east(Bitboard b) { return (b & 0x7f7f7f7f7f7f7f7
 constexpr inline Bitboard south_west(Bitboard b) { return (b & 0xfefefefefefefefeULL) >> 9; }
 
 /**
+ * @brief Wrapper used to pretty-print bitboards without colliding with integer overloads.
+ */
+struct BitboardPretty {
+    Bitboard value;
+};
+
+/**
+ * @brief Helper that returns a printable wrapper for @p b.
+ */
+[[nodiscard]] BitboardPretty pretty(Bitboard b);
+
+/**
  * @brief Convenience stream operator for printing bitboards during debugging.
  */
-std::ostream& operator<<(std::ostream& os, Bitboard b);
+std::ostream& operator<<(std::ostream& os, BitboardPretty pretty);
 
 }  // namespace chiron
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,9 +2,9 @@
 
 #include <algorithm>
 #include <exception>
-#include <algorithm>
 #include <filesystem>
 #include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <random>
 #include <stdexcept>
@@ -120,6 +120,8 @@ int run_selfplay(const std::vector<std::string>& args) {
             config.capture_pgn = false;
         } else if (opt == "--record-fens") {
             config.record_fens = true;
+        } else if (opt == "--verbose") {
+            config.verbose = true;
         } else if (opt == "--max-ply") {
             config.max_ply = parse_int(args, i, opt);
         } else if (opt == "--seed") {
@@ -168,6 +170,9 @@ int run_selfplay(const std::vector<std::string>& args) {
         } else if (opt == "--training-output") {
             if (i + 1 >= args.size()) throw std::invalid_argument(opt + " requires a value");
             config.training_output_path = args[++i];
+        } else if (opt == "--training-history") {
+            if (i + 1 >= args.size()) throw std::invalid_argument(opt + " requires a value");
+            config.training_history_dir = args[++i];
         } else {
             throw std::invalid_argument("Unknown selfplay option: " + opt);
         }
@@ -252,6 +257,13 @@ int run_sprt(const std::vector<std::string>& args) {
     std::cout << "Games: " << summary.games_played << ", candidate wins: " << summary.candidate_wins
               << ", baseline wins: " << summary.baseline_wins << ", draws: " << summary.draws << "\n";
     std::cout << "LLR: " << summary.llr << "\n";
+    if (summary.elo) {
+        std::cout << "Estimated Elo: " << std::fixed << std::setprecision(2) << *summary.elo;
+        if (summary.elo_confidence) {
+            std::cout << " ±" << *summary.elo_confidence;
+        }
+        std::cout << std::defaultfloat << std::setprecision(6) << "\n";
+    }
     return 0;
 }
 

--- a/tools/tuning.cpp
+++ b/tools/tuning.cpp
@@ -126,6 +126,17 @@ SprtSummary SprtTester::run() {
     summary.baseline_wins = baseline_wins_;
     summary.draws = draws_;
 
+    double wins = static_cast<double>(candidate_wins_) + 0.5 * static_cast<double>(draws_);
+    double losses = static_cast<double>(baseline_wins_) + 0.5 * static_cast<double>(draws_);
+    if (wins > 0.0 && losses > 0.0) {
+        double ratio = wins / losses;
+        double elo = 400.0 * std::log10(ratio);
+        double variance = (1.0 / wins) + (1.0 / losses);
+        double sigma = (400.0 / std::log(10.0)) * std::sqrt(variance);
+        summary.elo = elo;
+        summary.elo_confidence = 1.96 * sigma;
+    }
+
     if (log_stream) {
         log_stream.flush();
     }

--- a/tools/tuning.h
+++ b/tools/tuning.h
@@ -2,6 +2,7 @@
 
 #include <fstream>
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "tools/time_manager.h"
@@ -26,6 +27,8 @@ struct SprtSummary {
     int candidate_wins = 0;
     int baseline_wins = 0;
     int draws = 0;
+    std::optional<double> elo;
+    std::optional<double> elo_confidence;
 };
 
 class SprtTester {

--- a/training/selfplay.h
+++ b/training/selfplay.h
@@ -31,6 +31,7 @@ struct SelfPlayConfig {
     bool capture_results = true;
     bool capture_pgn = true;
     bool record_fens = false;
+    bool verbose = false;
     std::string results_log = "selfplay_results.jsonl";
     std::string pgn_path = "selfplay_games.pgn";
     bool append_logs = true;
@@ -39,7 +40,8 @@ struct SelfPlayConfig {
     bool enable_training = false;
     std::size_t training_batch_size = 256;
     double training_learning_rate = 0.05;
-    std::string training_output_path = "trained.nnue";
+    std::string training_output_path = "nnue/models/chiron-selfplay-latest.nnue";
+    std::string training_history_dir = "nnue/models/history";
 };
 
 struct SelfPlayResult {
@@ -68,6 +70,7 @@ class SelfPlayOrchestrator {
     void write_pgn(int game_index, const SelfPlayResult& result);
     void ensure_streams();
     void handle_training(const SelfPlayResult& result);
+    void log_verbose(const std::string& message);
 
     SelfPlayConfig config_;
     std::mt19937 rng_;
@@ -79,6 +82,13 @@ class SelfPlayOrchestrator {
     Trainer trainer_;
     ParameterSet parameters_;
     std::vector<TrainingExample> training_buffer_;
+    int training_iteration_ = 0;
+    std::string training_history_prefix_;
+    std::string training_history_extension_;
+    std::size_t total_positions_collected_ = 0;
+    std::size_t total_positions_trained_ = 0;
+
+    int detect_existing_history_iteration() const;
 };
 
 }  // namespace chiron


### PR DESCRIPTION
## Summary
- add a `--verbose` self-play switch that streams per-move search metrics, PVs, and game summaries to stdout
- surface training-buffer collection counts and iteration saves when verbose mode is enabled, with counters that survive restarts
- document verbose telemetry in the README so both chess and AI workflows can discover the new option

## Testing
- cmake --build build
- ctest --test-dir build
- ./build/chiron selfplay --games 1 --depth 2 --concurrency 1 --no-results --no-pgn --verbose


------
https://chatgpt.com/codex/tasks/task_b_68d3d0e3bfd8832dbb63dab241ab2a24