### PR TITLE
Fix self-play race condition and improve verbose diagnostics

### DIFF
--- a/training/selfplay.h
+++ b/training/selfplay.h
@@ -79,6 +79,7 @@ class SelfPlayOrchestrator {
     bool streams_open_ = false;
     std::mutex log_mutex_;
     std::mutex training_mutex_;
+    mutable std::mutex config_mutex_;
     Trainer trainer_;
     ParameterSet parameters_;
     std::vector<TrainingExample> training_buffer_;


### PR DESCRIPTION
## Summary
- guard updates to the shared self-play engine configuration so concurrent games always see a consistent network path
- add a verbose log entry before each search starts to aid debugging when a move takes a long time

## Testing
- cmake --build build --config Debug
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_b_68d51d5a80f8832da8c4f22231a3b34d