### PR TITLE
Fix aspiration search infinite loop on mate scores

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -197,20 +197,35 @@ SearchResult Search::search_impl(Board& board, const SearchLimits& limits, std::
             if (stop_flag.load()) {
                 break;
             }
+
+            bool widened = false;
             if (score <= alpha) {
+                if (alpha <= -kInfinity) {
+                    completed_window = true;
+                    break;
+                }
                 alpha = std::max(-kInfinity, alpha - aspiration);
-                aspiration *= 2;
+                widened = true;
             } else if (score >= beta) {
+                if (beta >= kInfinity) {
+                    completed_window = true;
+                    break;
+                }
                 beta = std::min(kInfinity, beta + aspiration);
-                aspiration *= 2;
+                widened = true;
             } else {
                 completed_window = true;
                 break;
             }
-            if (aspiration > kInfinity / 2) {
-                alpha = -kInfinity;
-                beta = kInfinity;
+
+            if (widened) {
+                aspiration = std::min(aspiration * 2, kInfinity);
+                if (aspiration > kInfinity / 2) {
+                    alpha = -kInfinity;
+                    beta = kInfinity;
+                }
             }
+
             if (should_stop()) {
                 break;
             }

--- a/training/selfplay.h
+++ b/training/selfplay.h
@@ -79,6 +79,7 @@ class SelfPlayOrchestrator {
     bool streams_open_ = false;
     std::mutex log_mutex_;
     std::mutex training_mutex_;
+    mutable std::mutex config_mutex_;
     Trainer trainer_;
     ParameterSet parameters_;
     std::vector<TrainingExample> training_buffer_;


### PR DESCRIPTION
## Summary
- stop the aspiration-window retry loop from spinning forever when a mate score hits the search bounds by breaking once the window is fully widened

## Testing
- cmake --build build
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_b_68d51d5a80f8832da8c4f22231a3b34d