### PR TITLE
Add verboselite mode and configurable wider NNUE network

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,15 +131,17 @@ Key options:
 * `--training-rate RATE` – Learning rate for the internal trainer.
 * `--training-output PATH` – Where to store the continually updated NNUE weights.
 * `--training-history DIR` – Optional directory for archiving per-step snapshots.
+* `--training-hidden SIZE` – Number of hidden neurons used when initialising a new NNUE evaluator.
 
 
 * `--verbose` – Print per-move search telemetry and training updates during self-play.
+* `--verboselite` – Emit a single line summary as each game finishes without the full move-by-move trace.
 
 Training batches are accumulated from every game (start position plus subsequent FENs). When the buffer exceeds the requested batch size, the trainer performs an optimisation step, saves the updated network, and reloads it for subsequent games.
 
 ### Verbose Telemetry
 
-Enable `--verbose` to monitor self-play in real time. Each move is reported with its SAN notation, search depth/seldepth, evaluation (centipawns or mate score), node counts, NPS, elapsed time, and the current principal variation—useful insight for chess programmers inspecting move ordering and search stability. After every game, and whenever the training buffer flushes, verbose mode also prints how many positions were collected, the running totals processed, and where updated NNUE weights and history snapshots were written, giving AI practitioners clear feedback on dataset growth and model iteration cadence.
+Enable `--verbose` to monitor self-play in real time. Each move is reported with its SAN notation, search depth/seldepth, evaluation (centipawns or mate score), node counts, NPS, elapsed time, and the current principal variation—useful insight for chess programmers inspecting move ordering and search stability. After every game, and whenever the training buffer flushes, verbose mode also prints how many positions were collected, the running totals processed, and where updated NNUE weights and history snapshots were written, giving AI practitioners clear feedback on dataset growth and model iteration cadence. When you only need lightweight progress feedback, `--verboselite` prints a concise “Game N complete” line capturing the result, termination reason, and duration while keeping the console quiet between moves.
 
 ### Model Storage
 

--- a/TRAINING_GUIDE.md
+++ b/TRAINING_GUIDE.md
@@ -29,9 +29,9 @@ Chiron ships with a lightweight NNUE evaluator. To bootstrap training:
      --training-history nnue/models/history \
      --results logs/results.jsonl \
      --pgn logs/selfplay.pgn \
-     --verbose
+     --verboselite
    ```
-2. The orchestrator automatically streams search telemetry (with `--verbose`), saves the continually updated network to `nnue/models/chiron-selfplay-latest.nnue`, and writes snapshot checkpoints to `nnue/models/history/` every optimisation step. This ensures each training run builds on the previous weights instead of starting from scratch.
+2. The orchestrator automatically streams search telemetry (with `--verbose`), saves the continually updated network to `nnue/models/chiron-selfplay-latest.nnue`, and writes snapshot checkpoints to `nnue/models/history/` every optimisation step. This ensures each training run builds on the previous weights instead of starting from scratch. Swap `--verboselite` for `--verbose` if you only need to know when games finish without the detailed move trace.
 
 ## 3. Grow the Training Dataset
 
@@ -63,7 +63,7 @@ Chiron ships with a lightweight NNUE evaluator. To bootstrap training:
      --rate 0.03 \
      --shuffle
    ```
-3. Replace the runtime network by pointing self-play or the UCI option to the freshly trained weights:
+3. Replace the runtime network by pointing self-play or the UCI option to the freshly trained weights. Pass `--training-hidden <SIZE>` during self-play (or `--hidden <SIZE>` to the offline `train` command) to start from a wider NNUE with more hidden neurons when you want additional model capacity.
    ```bash
    ./build/chiron selfplay --enable-training --training-output nnue/models/offline-latest.nnue
    ```

--- a/nnue/evaluator.h
+++ b/nnue/evaluator.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <array>
 #include <atomic>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <vector>
 
 #include "board.h"
 #include "move.h"
@@ -19,9 +19,13 @@ constexpr int kMaxEvaluationMagnitude = 30000;
  * @brief Accumulator storing the summed NNUE feature contributions for both colors.
  */
 struct Accumulator {
-    std::array<int32_t, kNumColors> material{};
+    std::vector<int32_t> white;
+    std::vector<int32_t> black;
 
-    void reset() { material.fill(0); }
+    void reset(std::size_t hidden_size) {
+        white.assign(hidden_size, 0);
+        black.assign(hidden_size, 0);
+    }
 };
 
 /**

--- a/nnue/network.cpp
+++ b/nnue/network.cpp
@@ -1,6 +1,7 @@
 #include "network.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstring>
 #include <fstream>
 #include <stdexcept>
@@ -9,19 +10,18 @@
 namespace chiron::nnue {
 
 namespace {
-constexpr char kMagic[4] = {'N', 'N', 'U', 'E'};
-constexpr std::uint32_t kSupportedVersion = 1U;
 
-struct DiskHeader {
-    char magic[4];
-    std::uint32_t version = 0;
-    std::uint32_t feature_count = 0;
-    std::int32_t bias = 0;
-    float scale = 1.0F;
-};
+constexpr char kMagic[4] = {'N', 'N', 'U', 'E'};
+constexpr std::uint32_t kVersionV1 = 1U;
+constexpr std::uint32_t kVersionV2 = 2U;
 
 constexpr int kDefaultPieceValues[static_cast<int>(PieceType::King) + 1] = {
     100, 320, 330, 500, 900, 20000};
+
+std::size_t weight_offset(std::size_t feature, std::size_t neuron) {
+    return neuron * kFeatureCount + feature;
+}
+
 }  // namespace
 
 std::size_t feature_index(Color color, PieceType piece, int square) {
@@ -38,106 +38,269 @@ std::size_t feature_index(Color color, PieceType piece, int square) {
 
 Network::Network() = default;
 
+void Network::ensure_storage(std::size_t hidden_size) {
+    hidden_size_ = std::max<std::size_t>(1, hidden_size);
+    input_weights_.assign(hidden_size_ * kFeatureCount, 0);
+    hidden_biases_.assign(hidden_size_, 0);
+    output_weights_.assign(hidden_size_, 0.0F);
+}
+
+void Network::set_hidden_size(std::size_t hidden_size) {
+    ensure_storage(hidden_size);
+    loaded_ = true;
+}
+
 void Network::load_from_file(const std::string& path) {
     std::ifstream stream(path, std::ios::binary);
     if (!stream) {
         throw std::runtime_error("Failed to open NNUE network file: " + path);
     }
 
-    DiskHeader header{};
-    stream.read(reinterpret_cast<char*>(&header), sizeof(header));
-    if (!stream) {
-        throw std::runtime_error("Failed to read NNUE network header from file: " + path);
-    }
-    if (std::memcmp(header.magic, kMagic, sizeof(kMagic)) != 0) {
+    char magic[4];
+    stream.read(magic, sizeof(magic));
+    if (!stream || std::memcmp(magic, kMagic, sizeof(kMagic)) != 0) {
         throw std::runtime_error("Invalid NNUE network file: magic mismatch");
     }
-    if (header.version != kSupportedVersion) {
-        throw std::runtime_error("Unsupported NNUE network version: " + std::to_string(header.version));
+
+    std::uint32_t version = 0;
+    stream.read(reinterpret_cast<char*>(&version), sizeof(version));
+    if (!stream) {
+        throw std::runtime_error("Failed to read NNUE network version");
     }
-    if (header.feature_count != kFeatureCount) {
+
+    std::uint32_t feature_count = 0;
+    stream.read(reinterpret_cast<char*>(&feature_count), sizeof(feature_count));
+    if (!stream) {
+        throw std::runtime_error("Failed to read NNUE feature count");
+    }
+    if (feature_count != kFeatureCount) {
         throw std::runtime_error("Unexpected feature count in NNUE network file");
     }
 
-    std::vector<int16_t> buffer(header.feature_count);
-    stream.read(reinterpret_cast<char*>(buffer.data()), static_cast<std::streamsize>(buffer.size() * sizeof(int16_t)));
+    if (version == kVersionV1) {
+        std::int32_t bias = 0;
+        float scale = 1.0F;
+        stream.read(reinterpret_cast<char*>(&bias), sizeof(bias));
+        stream.read(reinterpret_cast<char*>(&scale), sizeof(scale));
+        if (!stream) {
+            throw std::runtime_error("Failed to read NNUE network parameters");
+        }
+
+        std::vector<int16_t> buffer(feature_count);
+        stream.read(reinterpret_cast<char*>(buffer.data()),
+                    static_cast<std::streamsize>(buffer.size() * sizeof(int16_t)));
+        if (!stream) {
+            throw std::runtime_error("Failed to read NNUE weights from file: " + path);
+        }
+
+        ensure_storage(1);
+        for (std::size_t i = 0; i < buffer.size(); ++i) {
+            input_weights_[i] = static_cast<int32_t>(buffer[i]);
+        }
+        hidden_biases_.assign(hidden_size_, 0);
+        output_weights_.assign(hidden_size_, 1.0F);
+        bias_ = bias;
+        scale_ = scale;
+        loaded_ = true;
+        return;
+    }
+
+    if (version != kVersionV2) {
+        throw std::runtime_error("Unsupported NNUE network version: " + std::to_string(version));
+    }
+
+    std::uint32_t hidden_size = 0;
+    stream.read(reinterpret_cast<char*>(&hidden_size), sizeof(hidden_size));
+    if (!stream) {
+        throw std::runtime_error("Failed to read NNUE hidden size");
+    }
+
+    std::int32_t bias = 0;
+    float scale = 1.0F;
+    stream.read(reinterpret_cast<char*>(&bias), sizeof(bias));
+    stream.read(reinterpret_cast<char*>(&scale), sizeof(scale));
+    if (!stream) {
+        throw std::runtime_error("Failed to read NNUE network parameters");
+    }
+
+    ensure_storage(hidden_size);
+
+    std::vector<int16_t> bias_buffer(hidden_size_);
+    stream.read(reinterpret_cast<char*>(bias_buffer.data()),
+                static_cast<std::streamsize>(bias_buffer.size() * sizeof(int16_t)));
+    if (!stream) {
+        throw std::runtime_error("Failed to read NNUE hidden biases");
+    }
+
+    std::vector<float> output_buffer(hidden_size_);
+    stream.read(reinterpret_cast<char*>(output_buffer.data()),
+                static_cast<std::streamsize>(output_buffer.size() * sizeof(float)));
+    if (!stream) {
+        throw std::runtime_error("Failed to read NNUE output weights");
+    }
+
+    std::vector<int16_t> weights_buffer(hidden_size_ * kFeatureCount);
+    stream.read(reinterpret_cast<char*>(weights_buffer.data()),
+                static_cast<std::streamsize>(weights_buffer.size() * sizeof(int16_t)));
     if (!stream) {
         throw std::runtime_error("Failed to read NNUE weights from file: " + path);
     }
 
-    std::fill(weights_.begin(), weights_.end(), 0);
-    for (std::size_t i = 0; i < buffer.size(); ++i) {
-        weights_[i] = static_cast<int32_t>(buffer[i]);
+    for (std::size_t i = 0; i < hidden_size_; ++i) {
+        hidden_biases_[i] = static_cast<int32_t>(bias_buffer[i]);
+        output_weights_[i] = output_buffer[i];
+    }
+    for (std::size_t i = 0; i < weights_buffer.size(); ++i) {
+        input_weights_[i] = static_cast<int32_t>(weights_buffer[i]);
     }
 
-    bias_ = header.bias;
-    scale_ = header.scale;
+    bias_ = bias;
+    scale_ = scale;
     loaded_ = true;
 }
 
-void Network::load_default() {
-    std::fill(weights_.begin(), weights_.end(), 0);
-    for (int color = 0; color < kNumColors; ++color) {
-        for (int piece = 0; piece < kNumPieceTypes; ++piece) {
-            PieceType type = static_cast<PieceType>(piece);
-            int value = kDefaultPieceValues[piece];
-            for (int square = 0; square < kBoardSize; ++square) {
-                weights_[feature_index(static_cast<Color>(color), type, square)] = value;
+void Network::load_default(std::size_t hidden_size) {
+    ensure_storage(hidden_size);
+    std::fill(hidden_biases_.begin(), hidden_biases_.end(), 0);
+    float output = hidden_size_ > 0 ? 1.0F / static_cast<float>(hidden_size_) : 1.0F;
+    std::fill(output_weights_.begin(), output_weights_.end(), output);
+
+    for (std::size_t neuron = 0; neuron < hidden_size_; ++neuron) {
+        for (int color = 0; color < kNumColors; ++color) {
+            for (int piece = 0; piece < kNumPieceTypes; ++piece) {
+                PieceType type = static_cast<PieceType>(piece);
+                int value = kDefaultPieceValues[piece];
+                for (int square = 0; square < kBoardSize; ++square) {
+                    std::size_t feature = feature_index(static_cast<Color>(color), type, square);
+                    input_weights_[weight_offset(feature, neuron)] = value;
+                }
             }
         }
     }
+
     bias_ = 0;
     scale_ = 1.0F;
     loaded_ = true;
 }
 
 void Network::save_to_file(const std::string& path) const {
-    DiskHeader header{};
-    std::memcpy(header.magic, kMagic, sizeof(kMagic));
-    header.version = kSupportedVersion;
-    header.feature_count = static_cast<std::uint32_t>(kFeatureCount);
-    header.bias = bias_;
-    header.scale = scale_;
-
-    std::vector<int16_t> buffer(kFeatureCount);
-    for (std::size_t i = 0; i < kFeatureCount; ++i) {
-        int32_t value = weights_[i];
-        value = std::clamp(value, static_cast<int32_t>(-32768), static_cast<int32_t>(32767));
-        buffer[i] = static_cast<int16_t>(value);
-    }
-
     std::ofstream stream(path, std::ios::binary | std::ios::trunc);
     if (!stream) {
         throw std::runtime_error("Failed to open NNUE network for writing: " + path);
     }
-    stream.write(reinterpret_cast<const char*>(&header), sizeof(header));
-    stream.write(reinterpret_cast<const char*>(buffer.data()), static_cast<std::streamsize>(buffer.size() * sizeof(int16_t)));
+
+    stream.write(kMagic, sizeof(kMagic));
+    std::uint32_t version = kVersionV2;
+    stream.write(reinterpret_cast<const char*>(&version), sizeof(version));
+    std::uint32_t feature_count = static_cast<std::uint32_t>(kFeatureCount);
+    stream.write(reinterpret_cast<const char*>(&feature_count), sizeof(feature_count));
+    std::uint32_t hidden = static_cast<std::uint32_t>(hidden_size_);
+    stream.write(reinterpret_cast<const char*>(&hidden), sizeof(hidden));
+    stream.write(reinterpret_cast<const char*>(&bias_), sizeof(bias_));
+    stream.write(reinterpret_cast<const char*>(&scale_), sizeof(scale_));
+
+    std::vector<int16_t> bias_buffer(hidden_size_);
+    for (std::size_t i = 0; i < hidden_size_; ++i) {
+        int32_t value = hidden_biases_[i];
+        value = std::clamp(value, static_cast<int32_t>(-32768), static_cast<int32_t>(32767));
+        bias_buffer[i] = static_cast<int16_t>(value);
+    }
+    stream.write(reinterpret_cast<const char*>(bias_buffer.data()),
+                 static_cast<std::streamsize>(bias_buffer.size() * sizeof(int16_t)));
+
+    stream.write(reinterpret_cast<const char*>(output_weights_.data()),
+                 static_cast<std::streamsize>(output_weights_.size() * sizeof(float)));
+
+    std::vector<int16_t> weights_buffer(hidden_size_ * kFeatureCount);
+    for (std::size_t i = 0; i < weights_buffer.size(); ++i) {
+        int32_t value = input_weights_[i];
+        value = std::clamp(value, static_cast<int32_t>(-32768), static_cast<int32_t>(32767));
+        weights_buffer[i] = static_cast<int16_t>(value);
+    }
+    stream.write(reinterpret_cast<const char*>(weights_buffer.data()),
+                 static_cast<std::streamsize>(weights_buffer.size() * sizeof(int16_t)));
+
     if (!stream) {
         throw std::runtime_error("Failed to write NNUE network file: " + path);
     }
 }
 
-int32_t Network::weight(Color color, PieceType piece, int square) const {
-    if (piece == PieceType::None || square < 0 || square >= kBoardSize) {
+int32_t Network::input_weight(Color color, PieceType piece, int square, std::size_t neuron) const {
+    if (piece == PieceType::None || square < 0 || square >= kBoardSize || neuron >= hidden_size_) {
         return 0;
     }
-    return weights_[feature_index(color, piece, square)];
+    std::size_t feature = feature_index(color, piece, square);
+    return input_weights_[weight_offset(feature, neuron)];
 }
 
-void Network::set_weight(Color color, PieceType piece, int square, int32_t value) {
-    if (piece == PieceType::None || square < 0 || square >= kBoardSize) {
+int32_t Network::input_weight(std::size_t feature, std::size_t neuron) const {
+    if (neuron >= hidden_size_ || feature >= kFeatureCount) {
+        return 0;
+    }
+    return input_weights_[weight_offset(feature, neuron)];
+}
+
+void Network::set_input_weight(Color color, PieceType piece, int square, int32_t value, std::size_t neuron) {
+    if (piece == PieceType::None || square < 0 || square >= kBoardSize || neuron >= hidden_size_) {
         return;
     }
-    weights_[feature_index(color, piece, square)] = value;
+    std::size_t feature = feature_index(color, piece, square);
+    input_weights_[weight_offset(feature, neuron)] = value;
     loaded_ = true;
 }
 
-void Network::add_weight(Color color, PieceType piece, int square, int32_t delta) {
-    if (piece == PieceType::None || square < 0 || square >= kBoardSize) {
+void Network::set_input_weight(std::size_t feature, std::size_t neuron, int32_t value) {
+    if (feature >= kFeatureCount || neuron >= hidden_size_) {
         return;
     }
-    std::size_t idx = feature_index(color, piece, square);
-    weights_[idx] += delta;
+    input_weights_[weight_offset(feature, neuron)] = value;
+    loaded_ = true;
+}
+
+void Network::add_input_weight(Color color, PieceType piece, int square, int32_t delta, std::size_t neuron) {
+    if (piece == PieceType::None || square < 0 || square >= kBoardSize || neuron >= hidden_size_) {
+        return;
+    }
+    std::size_t feature = feature_index(color, piece, square);
+    input_weights_[weight_offset(feature, neuron)] += delta;
+    loaded_ = true;
+}
+
+void Network::add_input_weight(std::size_t feature, std::size_t neuron, int32_t delta) {
+    if (feature >= kFeatureCount || neuron >= hidden_size_) {
+        return;
+    }
+    input_weights_[weight_offset(feature, neuron)] += delta;
+    loaded_ = true;
+}
+
+int32_t Network::hidden_bias(std::size_t neuron) const {
+    if (neuron >= hidden_size_) {
+        return 0;
+    }
+    return hidden_biases_[neuron];
+}
+
+void Network::set_hidden_bias(std::size_t neuron, int32_t value) {
+    if (neuron >= hidden_size_) {
+        return;
+    }
+    hidden_biases_[neuron] = value;
+    loaded_ = true;
+}
+
+float Network::output_weight(std::size_t neuron) const {
+    if (neuron >= hidden_size_) {
+        return 0.0F;
+    }
+    return output_weights_[neuron];
+}
+
+void Network::set_output_weight(std::size_t neuron, float value) {
+    if (neuron >= hidden_size_) {
+        return;
+    }
+    output_weights_[neuron] = value;
     loaded_ = true;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,6 +30,7 @@ using chiron::TrainingExample;
 using chiron::load_training_file;
 using chiron::perft;
 using chiron::save_training_file;
+using chiron::nnue::kDefaultHiddenSize;
 
 int parse_int(const std::vector<std::string>& args, std::size_t& index, const std::string& option) {
     if (index + 1 >= args.size()) {
@@ -122,6 +123,8 @@ int run_selfplay(const std::vector<std::string>& args) {
             config.record_fens = true;
         } else if (opt == "--verbose") {
             config.verbose = true;
+        } else if (opt == "--verboselite") {
+            config.verbose_lite = true;
         } else if (opt == "--max-ply") {
             config.max_ply = parse_int(args, i, opt);
         } else if (opt == "--seed") {
@@ -173,6 +176,8 @@ int run_selfplay(const std::vector<std::string>& args) {
         } else if (opt == "--training-history") {
             if (i + 1 >= args.size()) throw std::invalid_argument(opt + " requires a value");
             config.training_history_dir = args[++i];
+        } else if (opt == "--training-hidden") {
+            config.training_hidden_size = parse_size(args, i, opt);
         } else {
             throw std::invalid_argument("Unknown selfplay option: " + opt);
         }
@@ -310,6 +315,7 @@ int run_train_command(const std::vector<std::string>& args) {
     std::string output_path = "trained.nnue";
     double learning_rate = 0.05;
     std::size_t batch_size = 256;
+    std::size_t hidden_size = kDefaultHiddenSize;
     int iterations = 1;
     bool shuffle = false;
 
@@ -329,6 +335,8 @@ int run_train_command(const std::vector<std::string>& args) {
             iterations = parse_int(args, i, opt);
         } else if (opt == "--shuffle") {
             shuffle = true;
+        } else if (opt == "--hidden") {
+            hidden_size = parse_size(args, i, opt);
         }
     }
 
@@ -346,7 +354,7 @@ int run_train_command(const std::vector<std::string>& args) {
         std::shuffle(data.begin(), data.end(), rng);
     }
 
-    ParameterSet parameters;
+    ParameterSet parameters(hidden_size);
     if (!output_path.empty() && std::filesystem::exists(output_path)) {
         parameters.load(output_path);
     }

--- a/training/selfplay.h
+++ b/training/selfplay.h
@@ -32,6 +32,7 @@ struct SelfPlayConfig {
     bool capture_pgn = true;
     bool record_fens = false;
     bool verbose = false;
+    bool verbose_lite = false;
     std::string results_log = "selfplay_results.jsonl";
     std::string pgn_path = "selfplay_games.pgn";
     bool append_logs = true;
@@ -42,6 +43,7 @@ struct SelfPlayConfig {
     double training_learning_rate = 0.05;
     std::string training_output_path = "nnue/models/chiron-selfplay-latest.nnue";
     std::string training_history_dir = "nnue/models/history";
+    std::size_t training_hidden_size = nnue::kDefaultHiddenSize;
 };
 
 struct SelfPlayResult {
@@ -71,6 +73,7 @@ class SelfPlayOrchestrator {
     void ensure_streams();
     void handle_training(const SelfPlayResult& result);
     void log_verbose(const std::string& message);
+    void log_lite(const std::string& message);
 
     SelfPlayConfig config_;
     std::mt19937 rng_;

--- a/training/trainer.h
+++ b/training/trainer.h
@@ -21,8 +21,9 @@ struct TrainingExample {
  */
 class ParameterSet {
    public:
-    ParameterSet();
+    explicit ParameterSet(std::size_t hidden_size = nnue::kDefaultHiddenSize);
 
+    void reset(std::size_t hidden_size);
     void load(const std::string& path);
     void save(const std::string& path) const;
 


### PR DESCRIPTION
## Summary
- add a `--verboselite` self-play option that prints concise per-game completion summaries while keeping the existing verbose stream intact
- redesign the NNUE evaluation to support configurable hidden layer sizes, update the trainer/evaluator to use the wider network and provide CLI flags to set the width
- document the new logging mode and network sizing options in the README and training guide

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build


------
https://chatgpt.com/codex/tasks/task_b_68d581be11cc832da94884ab288c30f9