### PR TITLE
Add configurable randomness to self-play move selection

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
+#include <utility>
 #include <vector>
 
 #include "board.h"
@@ -41,6 +42,7 @@ struct SearchResult {
     int seldepth = 0;                                   /**< Maximum depth reached in the tree. */
     std::uint64_t nodes = 0;                            /**< Total nodes visited. */
     std::vector<Move> pv;                               /**< Principal variation line. */
+    std::vector<std::pair<Move, int>> root_moves;       /**< Root move candidates and scores. */
     std::chrono::milliseconds elapsed{0};               /**< Time consumed by the search. */
 };
 
@@ -121,7 +123,8 @@ class Search {
         std::vector<std::uint64_t> repetition_stack;
     };
 
-    int search_root(ThreadContext& ctx, Board& board, int depth, int alpha, int beta, Move& best_move);
+    int search_root(ThreadContext& ctx, Board& board, int depth, int alpha, int beta, Move& best_move,
+                    std::vector<std::pair<Move, int>>& root_scores);
     int search_root_worker(ThreadContext& ctx, Board& board, const Move& move, int depth, int alpha, int beta);
     int negamax(ThreadContext& ctx, Board& board, int depth, int alpha, int beta, bool allow_null, int ply);
     int quiescence(ThreadContext& ctx, Board& board, int alpha, int beta, int ply);

--- a/training/selfplay.h
+++ b/training/selfplay.h
@@ -44,6 +44,10 @@ struct SelfPlayConfig {
     std::string training_output_path = "nnue/models/chiron-selfplay-latest.nnue";
     std::string training_history_dir = "nnue/models/history";
     std::size_t training_hidden_size = nnue::kDefaultHiddenSize;
+    double randomness_temperature = 0.0;  /**< Softmax temperature for randomized move selection. */
+    int randomness_max_ply = 0;           /**< Apply randomness up to this ply (0 = entire game). */
+    int randomness_top_moves = 3;         /**< Consider at most this many moves when randomizing. */
+    int randomness_score_margin = 50;     /**< Only randomize among moves within this score margin (cp). */
 };
 
 struct SelfPlayResult {
@@ -74,6 +78,7 @@ class SelfPlayOrchestrator {
     void handle_training(const SelfPlayResult& result);
     void log_verbose(const std::string& message);
     void log_lite(const std::string& message);
+    Move select_move(const SearchResult& search_result, int ply);
 
     SelfPlayConfig config_;
     std::mt19937 rng_;


### PR DESCRIPTION
## Summary
- expose scored root move data from the search so self-play can inspect multiple candidate moves
- add configurable randomness controls (temperature, ply limit, top move count, score margin) to self-play
- select moves via softmax sampling to diversify games while keeping high-quality candidates

## Testing
- cmake --build build
- ctest --test-dir build


------
https://chatgpt.com/codex/tasks/task_b_68d65463e7f0832d8fe4dae3173fec47