### PR TITLE
Expose self-play randomness controls via CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ Key options:
 * `--training-output PATH` – Where to store the continually updated NNUE weights.
 * `--training-history DIR` – Optional directory for archiving per-step snapshots.
 * `--training-hidden SIZE` – Number of hidden neurons used when initialising a new NNUE evaluator.
+* `--randomness-temperature T` – Enable stochastic move selection with softmax temperature `T > 0`.
+* `--randomness-top-moves N` – Sample only among the top `N` root moves (default 3).
+* `--randomness-score-margin CP` – Restrict sampling to moves within `CP` centipawns of the best score.
+* `--randomness-max-ply P` – Apply randomness only through ply `P` (0 keeps it on for the whole game).
 
 
 * `--verbose` – Print per-move search telemetry and training updates during self-play.

--- a/TRAINING_GUIDE.md
+++ b/TRAINING_GUIDE.md
@@ -23,6 +23,8 @@ Chiron ships with a lightweight NNUE evaluator. To bootstrap training:
      --depth 8 \
      --concurrency 2 \
      --enable-training \
+     --randomness-temperature 0.35 \
+     --randomness-top-moves 4 \
      --training-batch 256 \
      --training-rate 0.05 \
      --training-output nnue/models/chiron-selfplay-latest.nnue \
@@ -31,6 +33,7 @@ Chiron ships with a lightweight NNUE evaluator. To bootstrap training:
      --pgn logs/selfplay.pgn \
      --verboselite
    ```
+   The randomness flags activate softmax sampling over the top moves reported by the search so early games explore different continuations instead of repeating deterministic best lines. Tune the temperature upward for more variety, shrink it toward zero to approach pure minimax play, cap the exploration window with `--randomness-top-moves`, tighten quality with `--randomness-score-margin`, and limit noise to the opening with `--randomness-max-ply` when you want sharp midgames after diverse starts.
 2. The orchestrator automatically streams search telemetry (with `--verbose`), saves the continually updated network to `nnue/models/chiron-selfplay-latest.nnue`, and writes snapshot checkpoints to `nnue/models/history/` every optimisation step. This ensures each training run builds on the previous weights instead of starting from scratch. Swap `--verboselite` for `--verbose` if you only need to know when games finish without the detailed move trace.
 
 ## 3. Grow the Training Dataset

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -178,6 +178,14 @@ int run_selfplay(const std::vector<std::string>& args) {
             config.training_history_dir = args[++i];
         } else if (opt == "--training-hidden") {
             config.training_hidden_size = parse_size(args, i, opt);
+        } else if (opt == "--randomness-temperature") {
+            config.randomness_temperature = parse_double(args, i, opt);
+        } else if (opt == "--randomness-top-moves") {
+            config.randomness_top_moves = parse_int(args, i, opt);
+        } else if (opt == "--randomness-score-margin") {
+            config.randomness_score_margin = parse_int(args, i, opt);
+        } else if (opt == "--randomness-max-ply") {
+            config.randomness_max_ply = parse_int(args, i, opt);
         } else {
             throw std::invalid_argument("Unknown selfplay option: " + opt);
         }

--- a/src/search.h
+++ b/src/search.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
+#include <utility>
 #include <vector>
 
 #include "board.h"
@@ -41,6 +42,7 @@ struct SearchResult {
     int seldepth = 0;                                   /**< Maximum depth reached in the tree. */
     std::uint64_t nodes = 0;                            /**< Total nodes visited. */
     std::vector<Move> pv;                               /**< Principal variation line. */
+    std::vector<std::pair<Move, int>> root_moves;       /**< Root move candidates and scores. */
     std::chrono::milliseconds elapsed{0};               /**< Time consumed by the search. */
 };
 
@@ -121,7 +123,8 @@ class Search {
         std::vector<std::uint64_t> repetition_stack;
     };
 
-    int search_root(ThreadContext& ctx, Board& board, int depth, int alpha, int beta, Move& best_move);
+    int search_root(ThreadContext& ctx, Board& board, int depth, int alpha, int beta, Move& best_move,
+                    std::vector<std::pair<Move, int>>& root_scores);
     int search_root_worker(ThreadContext& ctx, Board& board, const Move& move, int depth, int alpha, int beta);
     int negamax(ThreadContext& ctx, Board& board, int depth, int alpha, int beta, bool allow_null, int ply);
     int quiescence(ThreadContext& ctx, Board& board, int alpha, int beta, int ply);

--- a/training/selfplay.h
+++ b/training/selfplay.h
@@ -44,6 +44,10 @@ struct SelfPlayConfig {
     std::string training_output_path = "nnue/models/chiron-selfplay-latest.nnue";
     std::string training_history_dir = "nnue/models/history";
     std::size_t training_hidden_size = nnue::kDefaultHiddenSize;
+    double randomness_temperature = 0.0;  /**< Softmax temperature for randomized move selection. */
+    int randomness_max_ply = 0;           /**< Apply randomness up to this ply (0 = entire game). */
+    int randomness_top_moves = 3;         /**< Consider at most this many moves when randomizing. */
+    int randomness_score_margin = 50;     /**< Only randomize among moves within this score margin (cp). */
 };
 
 struct SelfPlayResult {
@@ -74,6 +78,7 @@ class SelfPlayOrchestrator {
     void handle_training(const SelfPlayResult& result);
     void log_verbose(const std::string& message);
     void log_lite(const std::string& message);
+    Move select_move(const SearchResult& search_result, int ply);
 
     SelfPlayConfig config_;
     std::mt19937 rng_;


### PR DESCRIPTION
## Summary
- add command-line flags so self-play runs can configure randomness temperature, move limits, score margin, and ply cap
- document the new randomness controls in the README and training guide self-play walkthrough

## Testing
- cmake --build build
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_b_68d65463e7f0832d8fe4dae3173fec47