### PR TITLE
Add Elo tracking and training performance reporting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(chiron_lib
     nnue/network.cpp
     nnue/evaluator.cpp
     training/selfplay.cpp
+    training/elo_tracker.cpp
     training/trainer.cpp
     training/gpu_backend.cpp
     training/pgn_importer.cpp

--- a/training/elo_tracker.cpp
+++ b/training/elo_tracker.cpp
@@ -1,0 +1,105 @@
+#include "training/elo_tracker.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace chiron {
+
+namespace {
+double expected_score(double rating_a, double rating_b) {
+    return 1.0 / (1.0 + std::pow(10.0, (rating_b - rating_a) / 400.0));
+}
+
+}  // namespace
+
+EloTracker::EloTracker(double initial_rating, double k_factor)
+    : initial_rating_(initial_rating), k_factor_(k_factor) {}
+
+EloTracker::GameUpdate EloTracker::record_game(const std::string& white, const std::string& black, double white_score) {
+    auto [white_it, white_inserted] = players_.try_emplace(white);
+    auto [black_it, black_inserted] = players_.try_emplace(black);
+    if (white_inserted) {
+        white_it->second.rating = initial_rating_;
+    }
+    if (black_inserted) {
+        black_it->second.rating = initial_rating_;
+    }
+
+    InternalStats& white_stats = white_it->second;
+    InternalStats& black_stats = black_it->second;
+
+    double expected_white = expected_score(white_stats.rating, black_stats.rating);
+    double expected_black = 1.0 - expected_white;
+
+    double previous_white = white_stats.rating;
+    double previous_black = black_stats.rating;
+
+    double black_score = 1.0 - white_score;
+    white_stats.rating += k_factor_ * (white_score - expected_white);
+    black_stats.rating += k_factor_ * (black_score - expected_black);
+
+    if (white_score > 0.75) {
+        ++white_stats.wins;
+        ++black_stats.losses;
+    } else if (white_score < 0.25) {
+        ++white_stats.losses;
+        ++black_stats.wins;
+    } else {
+        ++white_stats.draws;
+        ++black_stats.draws;
+    }
+
+    ++white_stats.games;
+    ++black_stats.games;
+    white_stats.score += white_score;
+    black_stats.score += black_score;
+
+    GameUpdate update;
+    update.white.name = white;
+    update.white.rating = white_stats.rating;
+    update.white.delta = white_stats.rating - previous_white;
+    update.white.games = white_stats.games;
+    update.white.wins = white_stats.wins;
+    update.white.draws = white_stats.draws;
+    update.white.losses = white_stats.losses;
+    update.white.score = white_stats.score;
+
+    update.black.name = black;
+    update.black.rating = black_stats.rating;
+    update.black.delta = black_stats.rating - previous_black;
+    update.black.games = black_stats.games;
+    update.black.wins = black_stats.wins;
+    update.black.draws = black_stats.draws;
+    update.black.losses = black_stats.losses;
+    update.black.score = black_stats.score;
+
+    update.expected_white = expected_white;
+    update.result = white_score;
+    return update;
+}
+
+std::vector<EloTracker::PlayerSummary> EloTracker::snapshot() const {
+    std::vector<PlayerSummary> table;
+    table.reserve(players_.size());
+    for (const auto& [name, stats] : players_) {
+        PlayerSummary summary;
+        summary.name = name;
+        summary.rating = stats.rating == 0.0 && stats.games == 0 ? initial_rating_ : stats.rating;
+        summary.games = stats.games;
+        summary.wins = stats.wins;
+        summary.draws = stats.draws;
+        summary.losses = stats.losses;
+        summary.score = stats.score;
+        table.push_back(summary);
+    }
+    std::sort(table.begin(), table.end(), [](const PlayerSummary& lhs, const PlayerSummary& rhs) {
+        if (std::fabs(lhs.rating - rhs.rating) > 1e-6) {
+            return lhs.rating > rhs.rating;
+        }
+        return lhs.name < rhs.name;
+    });
+    return table;
+}
+
+}  // namespace chiron
+

--- a/training/elo_tracker.h
+++ b/training/elo_tracker.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace chiron {
+
+/**
+ * @brief Lightweight Elo rating accumulator for tracking self-play progress.
+ */
+class EloTracker {
+   public:
+    struct PlayerSummary {
+        std::string name;
+        double rating = 0.0;
+        double delta = 0.0;
+        int games = 0;
+        int wins = 0;
+        int draws = 0;
+        int losses = 0;
+        double score = 0.0;
+    };
+
+    struct GameUpdate {
+        PlayerSummary white;
+        PlayerSummary black;
+        double expected_white = 0.5;
+        double result = 0.5;
+    };
+
+    EloTracker(double initial_rating = 1500.0, double k_factor = 24.0);
+
+    /**
+     * @brief Record a completed game and update both players' ratings.
+     * @param white Name of the white player.
+     * @param black Name of the black player.
+     * @param white_score Result for white (1 = win, 0.5 = draw, 0 = loss).
+     * @return Rating update details for both players.
+     */
+    GameUpdate record_game(const std::string& white, const std::string& black, double white_score);
+
+    /**
+     * @brief Snapshot of all tracked players sorted by rating.
+     */
+    std::vector<PlayerSummary> snapshot() const;
+
+   private:
+    struct InternalStats {
+        double rating = 0.0;
+        int games = 0;
+        int wins = 0;
+        int draws = 0;
+        int losses = 0;
+        double score = 0.0;
+    };
+
+    double initial_rating_;
+    double k_factor_;
+    std::unordered_map<std::string, InternalStats> players_;
+};
+
+}  // namespace chiron
+

--- a/training/selfplay.h
+++ b/training/selfplay.h
@@ -12,6 +12,7 @@
 #include "board.h"
 #include "search.h"
 #include "tools/teacher.h"
+#include "training/elo_tracker.h"
 #include "training/trainer.h"
 
 namespace chiron {
@@ -84,6 +85,8 @@ class SelfPlayOrchestrator {
     void handle_training(const SelfPlayResult& result);
     void log_verbose(const std::string& message);
     void log_lite(const std::string& message);
+    void record_elo(int game_index, const SelfPlayResult& result);
+    void log_rating_snapshot(const std::string& prefix);
     Move select_move(const SearchResult& search_result, int ply);
     void train_buffer_if_ready_locked(bool force);
     void process_teacher_batch(std::vector<std::string> fen_batch, bool force);
@@ -97,6 +100,7 @@ class SelfPlayOrchestrator {
     std::mutex log_mutex_;
     std::mutex training_mutex_;
     mutable std::mutex config_mutex_;
+    std::mutex elo_mutex_;
     Trainer trainer_;
     ParameterSet parameters_;
     std::vector<TrainingExample> training_buffer_;
@@ -107,6 +111,7 @@ class SelfPlayOrchestrator {
     std::string training_history_extension_;
     std::size_t total_positions_collected_ = 0;
     std::size_t total_positions_trained_ = 0;
+    EloTracker elo_tracker_{};
   
     int detect_existing_history_iteration() const;
 };


### PR DESCRIPTION
## Summary
- add an Elo tracker utility and wire it into self-play so each phase reports current ratings
- surface dataset pseudo-Elo summaries during the offline `train` command
- register the new tracking module in the build

## Testing
- cmake --build build
- ctest


------
https://chatgpt.com/codex/tasks/task_b_68d68ba7abb8832db0a17050299d0dca