### PR TITLE
Add integrated learn command for self-supervised regimen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,8 @@ add_library(chiron_lib
     training/trainer.cpp
     training/gpu_backend.cpp
     training/pgn_importer.cpp
+    training/training_metrics.cpp
+    training/learning_regimen.cpp
     tools/tuning.cpp
     tools/teacher.cpp
 )

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ The `chiron` executable also exposes a suite of helper commands:
 |---------|-------------|
 | `perft --depth N [--fen FEN]` | Executes a perft test from the current position. |
 | `selfplay [options]` | Runs concurrent self-play games (see below). |
+| `learn [iterations] [options]` | Launches the self-supervised regimen combining self-play, Stockfish supervision, and online PGNs. |
 | `train --input dataset.txt [--output net.nnue] [--rate 0.05] [--batch 256] [--iterations 3] [--shuffle]` | Trains the evaluator on a dataset of `fen|score` lines. |
 | `train-teacher --teacher /path/to/stockfish [--games 1M] [--depth 15] [--batch 2048] [--teacher-batch 512] [--device gpu]` | Runs Stockfish-supervised training that streams labelled positions directly into the NNUE trainer. |
 | `import-pgn --pgn games.pgn [--output dataset.txt] [--no-draws]` | Converts a PGN database into a training dataset. |
@@ -177,6 +178,35 @@ Key options:
 * `--verboselite` – Emit a single line summary as each game finishes without the full move-by-move trace.
 
 Training batches are accumulated from every game (start position plus subsequent FENs). When the buffer exceeds the requested batch size, the trainer performs an optimisation step, saves the updated network, and reloads it for subsequent games.
+
+### One-command learning regimen
+
+When you simply want to improve the bundled network and then play against it, run the integrated regimen:
+
+```bash
+./chiron -learn 1000 \
+  --teacher-engine /opt/engines/stockfish \
+  --selfplay-games 32 \
+  --teacher-games 16 \
+  --online-batch 4096
+```
+
+The `learn` command cycles through three complementary phases on each iteration:
+
+1. **Pure self-play** – Generates fresh experience with the current NNUE weights and immediately trains on the collected buffer.
+2. **Teacher-guided self-play** – Mirrors the same schedule but asks the configured Stockfish binary (or any UCI engine) to label positions for supervised updates.
+3. **Online replay** – Streams raw PGN games from `data/online_pgns/` directly into the trainer. Drop downloaded lichess/Chess.com databases into this folder—no pre-processing is required and files are discovered automatically.
+
+The regimen prints a concise log for each phase plus a pseudo-Elo/accuracy summary on a holdout slice sampled from your PGN databases, allowing you to track progress at a glance. Updated networks are written to `nnue/models/chiron-learned.nnue` after every online replay step so you can immediately load them via `setoption name EvalNetwork value nnue/models/chiron-learned.nnue` once training finishes.
+
+Key flags include:
+
+* `--iterations` (default from the positional argument) – Number of full cycles to execute.
+* `--teacher-engine PATH` / `--teacher-depth N` / `--teacher-threads N` – Configure the UCI teacher used during the supervised phase.
+* `--online-dir PATH` / `--online-batch SIZE` – Change where PGNs are read from and how many positions are replayed each iteration.
+* `--batch-size SIZE` / `--learning-rate RATE` / `--device cpu|gpu` – Control optimiser hyper-parameters shared across all phases.
+
+If no PGNs are found the online stage is skipped gracefully; the console reminds you where to place databases before training begins.
 
 ### Verbose Telemetry
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,8 +20,10 @@
 #include "tools/teacher.h"
 #include "tools/tuning.h"
 #include "training/pgn_importer.h"
+#include "training/learning_regimen.h"
 #include "training/selfplay.h"
 #include "training/trainer.h"
+#include "training/training_metrics.h"
 
 namespace {
 
@@ -32,6 +34,8 @@ using chiron::TeacherEngine;
 using chiron::Trainer;
 using chiron::TrainerDevice;
 using chiron::TrainingExample;
+using chiron::DatasetEvaluationResult;
+using chiron::evaluate_dataset_performance;
 using chiron::load_training_file;
 using chiron::perft;
 using chiron::save_training_file;
@@ -132,48 +136,6 @@ TrainerDevice parse_trainer_device_option(const std::string& value) {
         return TrainerDevice::kGPU;
     }
     throw std::invalid_argument("Unknown training device: " + value);
-}
-
-struct DatasetEvaluationResult {
-    double accuracy = 0.0;
-    double pseudo_elo = 0.0;
-    std::size_t samples = 0;
-};
-
-DatasetEvaluationResult evaluate_dataset_performance(const std::vector<TrainingExample>& data,
-                                                     const ParameterSet& parameters,
-                                                     const Trainer& trainer,
-                                                     std::size_t max_samples = 4096) {
-    DatasetEvaluationResult result;
-    if (data.empty() || max_samples == 0) {
-        return result;
-    }
-
-    std::size_t sample_count = std::min(max_samples, data.size());
-    double total_score = 0.0;
-    double step = static_cast<double>(data.size()) / static_cast<double>(sample_count);
-    for (std::size_t i = 0; i < sample_count; ++i) {
-        std::size_t index = static_cast<std::size_t>(i * step);
-        if (index >= data.size()) {
-            index = data.size() - 1;
-        }
-        const TrainingExample& example = data[index];
-        int predicted_cp = trainer.evaluate_example(example, parameters);
-        double predicted_prob = 1.0 / (1.0 + std::exp(-static_cast<double>(predicted_cp) / 400.0));
-        double actual_prob = 0.5;
-        if (example.target_cp > 50) {
-            actual_prob = 1.0;
-        } else if (example.target_cp < -50) {
-            actual_prob = 0.0;
-        }
-        total_score += 1.0 - std::fabs(predicted_prob - actual_prob);
-    }
-
-    result.samples = sample_count;
-    result.accuracy = total_score / static_cast<double>(sample_count);
-    double clipped = std::clamp(result.accuracy, 0.01, 0.99);
-    result.pseudo_elo = 400.0 * std::log10(clipped / (1.0 - clipped));
-    return result;
 }
 
 int run_perft(const std::vector<std::string>& args) {
@@ -429,6 +391,80 @@ int run_time_analysis(const std::vector<std::string>& args) {
 
     int sample = manager.allocate_time_ms(60000, 0, 20, static_cast<int>(report.recommended_moves_to_go));
     std::cout << "Sample allocation with 60s remaining: " << sample << " ms" << std::endl;
+    return 0;
+}
+
+int run_learn_command(const std::vector<std::string>& args) {
+    chiron::LearningRegimenConfig config;
+    std::size_t index = 1;
+
+    if (args.size() > 1 && !args[1].empty() && args[1].front() != '-') {
+        try {
+            config.iterations = std::stoi(args[1]);
+        } catch (const std::exception&) {
+            throw std::invalid_argument("Invalid iteration count: " + args[1]);
+        }
+        index = 2;
+    }
+
+    for (std::size_t i = index; i < args.size(); ++i) {
+        const std::string& opt = args[i];
+        if (opt == "--iterations") {
+            config.iterations = std::max(1, parse_int(args, i, opt));
+        } else if (opt == "--selfplay-games") {
+            config.selfplay_games = std::max(0, parse_int(args, i, opt));
+        } else if (opt == "--selfplay-depth") {
+            config.selfplay_depth = std::max(1, parse_int(args, i, opt));
+        } else if (opt == "--selfplay-concurrency") {
+            config.selfplay_concurrency = std::max(1, parse_int(args, i, opt));
+        } else if (opt == "--selfplay-max-ply") {
+            config.selfplay_max_ply = std::max(16, parse_int(args, i, opt));
+        } else if (opt == "--teacher-games") {
+            config.teacher_games = std::max(0, parse_int(args, i, opt));
+        } else if (opt == "--teacher-engine") {
+            if (i + 1 >= args.size()) throw std::invalid_argument(opt + " requires a value");
+            config.teacher_engine_path = args[++i];
+        } else if (opt == "--teacher-depth") {
+            config.teacher_depth = std::max(1, parse_int(args, i, opt));
+        } else if (opt == "--teacher-threads") {
+            config.teacher_threads = std::max(1, parse_int(args, i, opt));
+        } else if (opt == "--online-dir") {
+            if (i + 1 >= args.size()) throw std::invalid_argument(opt + " requires a value");
+            config.online_database_dir = args[++i];
+        } else if (opt == "--online-batch") {
+            config.online_batch_positions = parse_size(args, i, opt);
+        } else if (opt == "--learning-rate") {
+            config.learning_rate = parse_double(args, i, opt);
+        } else if (opt == "--batch-size") {
+            config.training_batch_size = parse_size(args, i, opt);
+        } else if (opt == "--output") {
+            if (i + 1 >= args.size()) throw std::invalid_argument(opt + " requires a value");
+            config.output_network_path = args[++i];
+        } else if (opt == "--history-dir") {
+            if (i + 1 >= args.size()) throw std::invalid_argument(opt + " requires a value");
+            config.training_history_dir = args[++i];
+        } else if (opt == "--hidden-size") {
+            config.hidden_size = parse_size(args, i, opt);
+        } else if (opt == "--device") {
+            if (i + 1 >= args.size()) throw std::invalid_argument(opt + " requires a value");
+            config.training_device = parse_trainer_device_option(args[++i]);
+        } else if (opt == "--holdout") {
+            config.holdout_samples = parse_size(args, i, opt);
+        } else if (opt == "--include-draws") {
+            config.include_draws = true;
+        } else if (opt == "--no-draws") {
+            config.include_draws = false;
+        } else {
+            throw std::invalid_argument("Unknown learn option: " + opt);
+        }
+    }
+
+    if (config.iterations <= 0) {
+        throw std::invalid_argument("learn iterations must be positive");
+    }
+
+    chiron::LearningRegimen regimen(config);
+    regimen.run();
     return 0;
 }
 
@@ -747,6 +783,9 @@ int main(int argc, char** argv) {
         }
         if (command == "perft") {
             return run_perft(args);
+        }
+        if (command == "learn" || command == "-learn" || command == "--learn") {
+            return run_learn_command(args);
         }
         if (command == "train") {
             return run_train_command(args);

--- a/training/learning_regimen.cpp
+++ b/training/learning_regimen.cpp
@@ -1,0 +1,303 @@
+#include "training/learning_regimen.h"
+
+#include <algorithm>
+#include <cctype>
+#include <chrono>
+#include <ctime>
+#include <iomanip>
+#include <iostream>
+#include <random>
+#include <sstream>
+#include <stdexcept>
+
+namespace chiron {
+
+namespace {
+
+bool has_pgn_extension(const std::filesystem::path& path) {
+    if (!path.has_extension()) {
+        return false;
+    }
+    std::string ext = path.extension().string();
+    std::transform(ext.begin(), ext.end(), ext.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+    return ext == ".pgn";
+}
+
+std::string timestamp_string() {
+    auto now = std::chrono::system_clock::now();
+    std::time_t t = std::chrono::system_clock::to_time_t(now);
+    std::tm tm = *std::localtime(&t);
+    std::ostringstream oss;
+    oss << std::put_time(&tm, "%Y-%m-%d %H:%M:%S");
+    return oss.str();
+}
+
+}  // namespace
+
+LearningRegimen::LearningRegimen(LearningRegimenConfig config)
+    : config_(std::move(config)),
+      trainer_(Trainer::Config{config_.learning_rate, 0.0005, config_.training_device}),
+      parameters_(config_.hidden_size) {
+    ensure_directories();
+
+    if (!config_.output_network_path.empty() && std::filesystem::exists(config_.output_network_path)) {
+        parameters_.load(config_.output_network_path);
+        config_.hidden_size = parameters_.network().hidden_size();
+        parameters_loaded_ = true;
+    }
+
+    if (!config_.online_database_dir.empty()) {
+        std::filesystem::path dir(config_.online_database_dir);
+        if (std::filesystem::exists(dir)) {
+            for (const auto& entry : std::filesystem::directory_iterator(dir)) {
+                if (entry.is_regular_file() && has_pgn_extension(entry.path())) {
+                    online_files_.push_back(entry.path());
+                }
+            }
+        }
+        std::sort(online_files_.begin(), online_files_.end());
+    }
+
+    if (!online_files_.empty() && config_.holdout_samples > 0) {
+        std::mt19937 rng(static_cast<unsigned int>(std::random_device{}()));
+        for (const auto& path : online_files_) {
+            try {
+                std::vector<TrainingExample> examples = importer_.import_file(path.string(), config_.include_draws);
+                if (examples.empty()) {
+                    continue;
+                }
+                std::shuffle(examples.begin(), examples.end(), rng);
+                for (const TrainingExample& example : examples) {
+                    holdout_set_.push_back(example);
+                    if (holdout_set_.size() >= config_.holdout_samples) {
+                        break;
+                    }
+                }
+            } catch (const std::exception&) {
+                continue;
+            }
+            if (holdout_set_.size() >= config_.holdout_samples) {
+                break;
+            }
+        }
+        if (holdout_set_.size() > config_.holdout_samples) {
+            holdout_set_.resize(config_.holdout_samples);
+        }
+    }
+}
+
+void LearningRegimen::ensure_directories() const {
+    if (!config_.output_network_path.empty()) {
+        std::filesystem::path output_path(config_.output_network_path);
+        if (output_path.has_parent_path()) {
+            std::filesystem::create_directories(output_path.parent_path());
+        }
+    }
+    if (!config_.training_history_dir.empty()) {
+        std::filesystem::create_directories(config_.training_history_dir);
+    }
+    if (!config_.online_database_dir.empty()) {
+        std::filesystem::create_directories(config_.online_database_dir);
+    }
+}
+
+void LearningRegimen::announce_online_database_location() const {
+    std::cout << "[Learn] Online database directory: " << config_.online_database_dir << '\n';
+    if (online_files_.empty()) {
+        std::cout << "[Learn] Place raw PGN files from online sources into this directory. They will be parsed on the fly.\n";
+    } else {
+        std::cout << "[Learn] Found " << online_files_.size()
+                  << " PGN file(s). They will be cycled through during training." << std::endl;
+    }
+}
+
+void LearningRegimen::refresh_parameters_from_disk() {
+    if (!parameters_loaded_) {
+        parameters_.reset(config_.hidden_size);
+        parameters_loaded_ = true;
+    }
+    if (!config_.output_network_path.empty() && std::filesystem::exists(config_.output_network_path)) {
+        parameters_.load(config_.output_network_path);
+        config_.hidden_size = parameters_.network().hidden_size();
+    }
+}
+
+void LearningRegimen::save_parameters() {
+    if (config_.output_network_path.empty()) {
+        return;
+    }
+    parameters_.save(config_.output_network_path);
+}
+
+void LearningRegimen::log_dataset_summary(const std::string& prefix, const DatasetEvaluationResult& summary) const {
+    if (summary.samples == 0) {
+        return;
+    }
+    std::cout << prefix << std::fixed << std::setprecision(1) << summary.pseudo_elo
+              << ", accuracy " << std::setprecision(1) << (summary.accuracy * 100.0)
+              << "% over " << summary.samples << " samples" << std::defaultfloat << std::setprecision(6)
+              << std::endl;
+}
+
+std::vector<TrainingExample> LearningRegimen::load_online_examples(std::size_t max_positions) {
+    std::vector<TrainingExample> result;
+    if (online_files_.empty() || max_positions == 0) {
+        return result;
+    }
+
+    std::mt19937 rng(static_cast<unsigned int>(std::random_device{}()));
+    std::size_t attempts = 0;
+    while (result.size() < max_positions && attempts < online_files_.size()) {
+        const std::filesystem::path& path = online_files_[online_file_index_];
+        online_file_index_ = (online_file_index_ + 1) % online_files_.size();
+        ++attempts;
+        try {
+            std::vector<TrainingExample> examples = importer_.import_file(path.string(), config_.include_draws);
+            if (examples.empty()) {
+                continue;
+            }
+            std::shuffle(examples.begin(), examples.end(), rng);
+            std::size_t needed = max_positions - result.size();
+            if (examples.size() > needed) {
+                examples.resize(needed);
+            }
+            result.insert(result.end(), examples.begin(), examples.end());
+        } catch (const std::exception& ex) {
+            std::cout << "[Learn] Warning: failed to read " << path << ": " << ex.what() << std::endl;
+        }
+    }
+    return result;
+}
+
+void LearningRegimen::run_selfplay_phase(int iteration, int total_iterations) {
+    if (config_.selfplay_games <= 0) {
+        return;
+    }
+    std::cout << "[Learn] Iteration " << iteration << '/' << total_iterations << " self-play: "
+              << config_.selfplay_games << " games (depth " << config_.selfplay_depth << ")" << std::endl;
+
+    SelfPlayConfig sp;
+    sp.games = config_.selfplay_games;
+    sp.max_ply = config_.selfplay_max_ply;
+    sp.concurrency = std::max(1, config_.selfplay_concurrency);
+    sp.enable_training = true;
+    sp.training_batch_size = config_.training_batch_size;
+    sp.training_learning_rate = config_.learning_rate;
+    sp.training_device = config_.training_device;
+    sp.training_output_path = config_.output_network_path;
+    sp.training_history_dir = config_.training_history_dir;
+    sp.training_hidden_size = config_.hidden_size;
+    sp.white.max_depth = config_.selfplay_depth;
+    sp.black.max_depth = config_.selfplay_depth;
+    sp.white.name = "Chiron";
+    sp.black.name = "Chiron";
+    sp.capture_results = false;
+    sp.capture_pgn = false;
+    sp.verbose_lite = true;
+    sp.teacher_mode = false;
+
+    SelfPlayOrchestrator orchestrator(sp);
+    orchestrator.run();
+    refresh_parameters_from_disk();
+}
+
+void LearningRegimen::run_teacher_phase(int iteration, int total_iterations) {
+    if (config_.teacher_games <= 0 || config_.teacher_engine_path.empty()) {
+        return;
+    }
+    std::cout << "[Learn] Iteration " << iteration << '/' << total_iterations << " teacher-guided self-play: "
+              << config_.teacher_games << " games using " << config_.teacher_engine_path << std::endl;
+
+    SelfPlayConfig teacher_sp;
+    teacher_sp.games = config_.teacher_games;
+    teacher_sp.max_ply = config_.selfplay_max_ply;
+    teacher_sp.concurrency = std::max(1, config_.selfplay_concurrency);
+    teacher_sp.enable_training = true;
+    teacher_sp.training_batch_size = config_.training_batch_size;
+    teacher_sp.training_learning_rate = config_.learning_rate;
+    teacher_sp.training_device = config_.training_device;
+    teacher_sp.training_output_path = config_.output_network_path;
+    teacher_sp.training_history_dir = config_.training_history_dir;
+    teacher_sp.training_hidden_size = config_.hidden_size;
+    teacher_sp.white.max_depth = config_.selfplay_depth;
+    teacher_sp.black.max_depth = config_.selfplay_depth;
+    teacher_sp.capture_results = false;
+    teacher_sp.capture_pgn = false;
+    teacher_sp.verbose_lite = true;
+    teacher_sp.teacher_mode = true;
+    teacher_sp.teacher.engine_path = config_.teacher_engine_path;
+    teacher_sp.teacher.depth = config_.teacher_depth;
+    teacher_sp.teacher.threads = config_.teacher_threads;
+    teacher_sp.teacher_chunk_size = config_.training_batch_size;
+
+    SelfPlayOrchestrator orchestrator(teacher_sp);
+    orchestrator.run();
+    refresh_parameters_from_disk();
+}
+
+void LearningRegimen::run_online_phase(int iteration, int total_iterations) {
+    if (config_.online_batch_positions == 0) {
+        return;
+    }
+    std::vector<TrainingExample> dataset = load_online_examples(config_.online_batch_positions);
+    if (dataset.empty()) {
+        std::cout << "[Learn] Iteration " << iteration << '/' << total_iterations
+                  << " online phase skipped (no PGN data available)." << std::endl;
+        return;
+    }
+
+    std::cout << "[Learn] Iteration " << iteration << '/' << total_iterations << " online replay: "
+              << dataset.size() << " positions from PGNs" << std::endl;
+
+    refresh_parameters_from_disk();
+
+    std::size_t batch_size = std::max<std::size_t>(1, config_.training_batch_size);
+    for (std::size_t offset = 0; offset < dataset.size(); offset += batch_size) {
+        std::size_t end = std::min(offset + batch_size, dataset.size());
+        std::vector<TrainingExample> batch(dataset.begin() + static_cast<std::ptrdiff_t>(offset),
+                                           dataset.begin() + static_cast<std::ptrdiff_t>(end));
+        trainer_.train_batch(batch, parameters_);
+    }
+    total_positions_trained_ += dataset.size();
+    save_parameters();
+
+    DatasetEvaluationResult summary =
+        evaluate_dataset_performance(dataset, parameters_, trainer_, std::min<std::size_t>(dataset.size(), 4096));
+    log_dataset_summary("[Learn] Online replay pseudo-Elo ", summary);
+}
+
+void LearningRegimen::evaluate_holdout(int iteration) {
+    if (holdout_set_.empty()) {
+        return;
+    }
+    refresh_parameters_from_disk();
+    DatasetEvaluationResult summary = evaluate_dataset_performance(holdout_set_, parameters_, trainer_,
+                                                                   std::min(config_.holdout_samples, holdout_set_.size()));
+    std::ostringstream prefix;
+    prefix << "[Learn] Holdout after iteration " << iteration << " pseudo-Elo ";
+    log_dataset_summary(prefix.str(), summary);
+}
+
+void LearningRegimen::run() {
+    announce_online_database_location();
+    if (!holdout_set_.empty()) {
+        std::cout << "[Learn] Using " << holdout_set_.size() << " holdout samples for progress tracking." << std::endl;
+    }
+
+    for (int iteration = 1; iteration <= config_.iterations; ++iteration) {
+        std::cout << "[Learn] === Iteration " << iteration << " started at " << timestamp_string() << " ===" << std::endl;
+        run_selfplay_phase(iteration, config_.iterations);
+        run_teacher_phase(iteration, config_.iterations);
+        run_online_phase(iteration, config_.iterations);
+        evaluate_holdout(iteration);
+        std::cout << "[Learn] Iteration " << iteration << " complete. Cumulative supervised samples: "
+                  << total_positions_trained_ << std::endl;
+    }
+
+    std::cout << "[Learn] Training complete. Latest network saved to " << config_.output_network_path << std::endl;
+}
+
+}  // namespace chiron
+

--- a/training/learning_regimen.h
+++ b/training/learning_regimen.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <cstddef>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "training/pgn_importer.h"
+#include "training/selfplay.h"
+#include "training/trainer.h"
+#include "training/training_metrics.h"
+
+namespace chiron {
+
+struct LearningRegimenConfig {
+    int iterations = 1;
+    int selfplay_games = 8;
+    int selfplay_depth = 10;
+    int selfplay_concurrency = 1;
+    int selfplay_max_ply = 160;
+    int teacher_games = 4;
+    std::string teacher_engine_path;
+    int teacher_depth = 20;
+    int teacher_threads = 1;
+    std::string online_database_dir = "data/online_pgns";
+    std::size_t online_batch_positions = 2048;
+    std::size_t training_batch_size = 256;
+    double learning_rate = 0.05;
+    TrainerDevice training_device = TrainerDevice::kCPU;
+    std::string output_network_path = "nnue/models/chiron-learned.nnue";
+    std::string training_history_dir = "nnue/models/history";
+    std::size_t hidden_size = nnue::kDefaultHiddenSize;
+    std::size_t holdout_samples = 2048;
+    bool include_draws = true;
+};
+
+class LearningRegimen {
+   public:
+    explicit LearningRegimen(LearningRegimenConfig config);
+
+    void run();
+
+   private:
+    void announce_online_database_location() const;
+    void ensure_directories() const;
+    void run_selfplay_phase(int iteration, int total_iterations);
+    void run_teacher_phase(int iteration, int total_iterations);
+    void run_online_phase(int iteration, int total_iterations);
+    void refresh_parameters_from_disk();
+    void save_parameters();
+    void log_dataset_summary(const std::string& prefix, const DatasetEvaluationResult& summary) const;
+    std::vector<TrainingExample> load_online_examples(std::size_t max_positions);
+    void evaluate_holdout(int iteration);
+
+    LearningRegimenConfig config_;
+    Trainer trainer_;
+    ParameterSet parameters_;
+    PgnImporter importer_;
+    std::vector<std::filesystem::path> online_files_;
+    std::size_t online_file_index_ = 0;
+    std::vector<TrainingExample> holdout_set_;
+    bool parameters_loaded_ = false;
+    std::size_t total_positions_trained_ = 0;
+};
+
+}  // namespace chiron
+

--- a/training/training_metrics.cpp
+++ b/training/training_metrics.cpp
@@ -1,0 +1,45 @@
+#include "training/training_metrics.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace chiron {
+
+DatasetEvaluationResult evaluate_dataset_performance(const std::vector<TrainingExample>& data,
+                                                     const ParameterSet& parameters,
+                                                     const Trainer& trainer,
+                                                     std::size_t max_samples) {
+    DatasetEvaluationResult result;
+    if (data.empty() || max_samples == 0) {
+        return result;
+    }
+
+    std::size_t sample_count = std::min<std::size_t>(max_samples, data.size());
+    double total_score = 0.0;
+    double step = static_cast<double>(data.size()) / static_cast<double>(sample_count);
+    for (std::size_t i = 0; i < sample_count; ++i) {
+        std::size_t index = static_cast<std::size_t>(i * step);
+        if (index >= data.size()) {
+            index = data.size() - 1;
+        }
+        const TrainingExample& example = data[index];
+        int predicted_cp = trainer.evaluate_example(example, parameters);
+        double predicted_prob = 1.0 / (1.0 + std::exp(-static_cast<double>(predicted_cp) / 400.0));
+        double actual_prob = 0.5;
+        if (example.target_cp > 50) {
+            actual_prob = 1.0;
+        } else if (example.target_cp < -50) {
+            actual_prob = 0.0;
+        }
+        total_score += 1.0 - std::fabs(predicted_prob - actual_prob);
+    }
+
+    result.samples = sample_count;
+    result.accuracy = total_score / static_cast<double>(sample_count);
+    double clipped = std::clamp(result.accuracy, 0.01, 0.99);
+    result.pseudo_elo = 400.0 * std::log10(clipped / (1.0 - clipped));
+    return result;
+}
+
+}  // namespace chiron
+

--- a/training/training_metrics.h
+++ b/training/training_metrics.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+#include "training/trainer.h"
+
+namespace chiron {
+
+struct DatasetEvaluationResult {
+    double accuracy = 0.0;
+    double pseudo_elo = 0.0;
+    std::size_t samples = 0;
+};
+
+DatasetEvaluationResult evaluate_dataset_performance(const std::vector<TrainingExample>& data,
+                                                     const ParameterSet& parameters,
+                                                     const Trainer& trainer,
+                                                     std::size_t max_samples = 4096);
+
+}  // namespace chiron
+


### PR DESCRIPTION
## Summary
- add a reusable learning regimen that combines self-play, teacher guidance, and PGN replay while persisting NNUE updates
- expose the regimen through a one-shot `learn` CLI command, share dataset metrics utilities, and register new sources in the build
- document the workflow and PGN placement instructions for the streamlined training experience

## Testing
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_b_68da8ba63a60832dbe73cd190eacec8e