### PR TITLE
Fix PGN importer target orientation

### DIFF
--- a/tests/test_training.cpp
+++ b/tests/test_training.cpp
@@ -1,7 +1,9 @@
 #include <gtest/gtest.h>
 
 #include <filesystem>
+#include <fstream>
 
+#include "training/pgn_importer.h"
 #include "training/trainer.h"
 
 namespace chiron {
@@ -23,6 +25,34 @@ TEST(Training, SaveLoadRoundTrip) {
 
     std::filesystem::remove(temp);
     EXPECT_EQ(before, after);
+}
+
+TEST(Training, PgnImporterOrientsTargets) {
+    const char* pgn = R"([Event "Test"]
+[Site "Test"]
+[Date "2024.01.01"]
+[Round "1"]
+[White "White"]
+[Black "Black"]
+[Result "1-0"]
+
+1. e4 e5 2. Qh5 Ke7 3. Qxe5# 1-0
+)";
+
+    std::filesystem::path temp = std::filesystem::temp_directory_path() / "chiron-import-test.pgn";
+    {
+        std::ofstream out(temp);
+        ASSERT_TRUE(out.good());
+        out << pgn;
+    }
+
+    PgnImporter importer;
+    std::vector<TrainingExample> examples = importer.import_file(temp.string());
+    std::filesystem::remove(temp);
+
+    ASSERT_GE(examples.size(), 2u);
+    EXPECT_EQ(examples[0].target_cp, 1000);
+    EXPECT_EQ(examples[1].target_cp, -1000);
 }
 
 }  // namespace chiron


### PR DESCRIPTION
## Summary
- orient PGN training targets based on the side to move so black-to-move positions are labeled correctly
- improve header parsing and SAN handling in the PGN importer to capture result tags split across tokens
- add a unit test covering the importer to ensure alternating targets for the same game

## Testing
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_b_68daa2e93de8832d9794e8d7e916996e