### PR TITLE
Diversify self-play openings

### DIFF
--- a/training/selfplay.cpp
+++ b/training/selfplay.cpp
@@ -424,6 +424,10 @@ void SelfPlayOrchestrator::run() {
             log_verbose(randomness.str());
         }
 
+        if (config_.alternate_colors) {
+            log_verbose("[SelfPlay] Alternating colors within and across game pairs to vary opening perspectives.");
+        }
+
         if (config_.enable_training) {
             std::ostringstream train;
             train << "[Train] Batch size " << config_.training_batch_size << ", learning rate "
@@ -465,8 +469,14 @@ void SelfPlayOrchestrator::run() {
                     black = config_.black;
                     alternate_colors = config_.alternate_colors;
                 }
-                if (alternate_colors && (game % 2 == 1)) {
-                    std::swap(white, black);
+                if (alternate_colors) {
+                    int pair_index = game / 2;
+                    bool flip_pair_orientation = (pair_index % 2) == 1;
+                    bool second_game_in_pair = (game % 2) == 1;
+                    bool swap_colors = flip_pair_orientation ? !second_game_in_pair : second_game_in_pair;
+                    if (swap_colors) {
+                        std::swap(white, black);
+                    }
                 }
                 play_game(game, white, black, true);
             }

--- a/training/selfplay.h
+++ b/training/selfplay.h
@@ -51,10 +51,10 @@ struct SelfPlayConfig {
     bool teacher_mode = false;
     TeacherConfig teacher{};
     std::size_t teacher_chunk_size = 256;
-    double randomness_temperature = 0.0;  /**< Softmax temperature for randomized move selection. */
-    int randomness_max_ply = 0;           /**< Apply randomness up to this ply (0 = entire game). */
-    int randomness_top_moves = 3;         /**< Consider at most this many moves when randomizing. */
-    int randomness_score_margin = 50;     /**< Only randomize among moves within this score margin (cp). */
+    double randomness_temperature = 0.7;  /**< Softmax temperature for randomized move selection. */
+    int randomness_max_ply = 24;          /**< Apply randomness up to this ply (0 = entire game). */
+    int randomness_top_moves = 4;         /**< Consider at most this many moves when randomizing. */
+    int randomness_score_margin = 40;     /**< Only randomize among moves within this score margin (cp). */
 };
 
 struct SelfPlayResult {


### PR DESCRIPTION
## Summary
- enable temperature-based move sampling in self-play by default to add opening diversity
- alternate color assignments within and across game pairs so both sides see each opening

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68daac5d4660832d8d4ebd3e999ca0af