### PR TITLE
Add dataset composition logging for online and holdout sets

### DIFF
--- a/training/learning_regimen.h
+++ b/training/learning_regimen.h
@@ -51,6 +51,7 @@ class LearningRegimen {
     void log_dataset_summary(const std::string& prefix, const DatasetEvaluationResult& summary) const;
     std::vector<TrainingExample> load_online_examples(std::size_t max_positions);
     void evaluate_holdout(int iteration);
+    void log_dataset_composition(const std::string& label, const std::vector<TrainingExample>& data) const;
 
     LearningRegimenConfig config_;
     Trainer trainer_;


### PR DESCRIPTION
## Summary
- add dataset composition logging that reports side-to-move balance, target distribution, and sample FENs
- invoke the new logging when constructing the holdout slice and when loading online replay batches
- emit informative messages if no PGN files are available for the requested holdout sample size

## Testing
- cmake -S cai2 -B cai2/build
- cmake --build cai2/build


------
https://chatgpt.com/codex/tasks/task_b_68daac4a5164832db9c8a4a675f7f3ca