### PR TITLE
Add mean squared error reporting to training metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ The `learn` command cycles through three complementary phases on each iteration:
 2. **Teacher-guided self-play** – Mirrors the same schedule but asks the configured Stockfish binary (or any UCI engine) to label positions for supervised updates.
 3. **Online replay** – Streams raw PGN games from `data/online_pgns/` directly into the trainer. Drop downloaded lichess/Chess.com databases into this folder—no pre-processing is required and files are discovered automatically.
 
-The regimen prints a concise log for each phase plus a pseudo-Elo/accuracy summary on a holdout slice sampled from your PGN databases, allowing you to track progress at a glance. Updated networks are written to `nnue/models/chiron-learned.nnue` after every online replay step so you can immediately load them via `setoption name EvalNetwork value nnue/models/chiron-learned.nnue` once training finishes.
+The regimen prints a concise log for each phase plus a pseudo-Elo/accuracy/MSE summary on a holdout slice sampled from your PGN databases, allowing you to track progress at a glance. Updated networks are written to `nnue/models/chiron-learned.nnue` after every online replay step so you can immediately load them via `setoption name EvalNetwork value nnue/models/chiron-learned.nnue` once training finishes.
 
 Key flags include:
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -529,7 +529,8 @@ int run_train_command(const std::vector<std::string>& args) {
         }
         std::ostringstream oss;
         oss << prefix << std::fixed << std::setprecision(1) << eval.pseudo_elo
-            << ", accuracy " << std::setprecision(1) << (eval.accuracy * 100.0) << "% over " << eval.samples
+            << ", accuracy " << std::setprecision(1) << (eval.accuracy * 100.0)
+            << "%, MSE " << std::setprecision(1) << eval.mean_squared_error << " over " << eval.samples
             << " samples";
         std::cout << oss.str() << std::endl;
     };

--- a/training/learning_regimen.cpp
+++ b/training/learning_regimen.cpp
@@ -137,7 +137,8 @@ void LearningRegimen::log_dataset_summary(const std::string& prefix, const Datas
     }
     std::cout << prefix << std::fixed << std::setprecision(1) << summary.pseudo_elo
               << ", accuracy " << std::setprecision(1) << (summary.accuracy * 100.0)
-              << "% over " << summary.samples << " samples" << std::defaultfloat << std::setprecision(6)
+              << "%, MSE " << std::setprecision(1) << summary.mean_squared_error
+              << " over " << summary.samples << " samples" << std::defaultfloat << std::setprecision(6)
               << std::endl;
 }
 

--- a/training/training_metrics.cpp
+++ b/training/training_metrics.cpp
@@ -16,6 +16,7 @@ DatasetEvaluationResult evaluate_dataset_performance(const std::vector<TrainingE
 
     std::size_t sample_count = std::min<std::size_t>(max_samples, data.size());
     double total_score = 0.0;
+    double total_squared_error = 0.0;
     double step = static_cast<double>(data.size()) / static_cast<double>(sample_count);
     for (std::size_t i = 0; i < sample_count; ++i) {
         std::size_t index = static_cast<std::size_t>(i * step);
@@ -32,10 +33,13 @@ DatasetEvaluationResult evaluate_dataset_performance(const std::vector<TrainingE
             actual_prob = 0.0;
         }
         total_score += 1.0 - std::fabs(predicted_prob - actual_prob);
+        double cp_error = static_cast<double>(predicted_cp - example.target_cp);
+        total_squared_error += cp_error * cp_error;
     }
 
     result.samples = sample_count;
     result.accuracy = total_score / static_cast<double>(sample_count);
+    result.mean_squared_error = total_squared_error / static_cast<double>(sample_count);
     double clipped = std::clamp(result.accuracy, 0.01, 0.99);
     result.pseudo_elo = 400.0 * std::log10(clipped / (1.0 - clipped));
     return result;

--- a/training/training_metrics.h
+++ b/training/training_metrics.h
@@ -10,6 +10,7 @@ namespace chiron {
 struct DatasetEvaluationResult {
     double accuracy = 0.0;
     double pseudo_elo = 0.0;
+    double mean_squared_error = 0.0;
     std::size_t samples = 0;
 };
 


### PR DESCRIPTION
## Summary
- compute mean squared error for dataset evaluation results alongside pseudo-Elo
- include MSE in trainer CLI logging for both learning regimen and manual training runs
- document the richer pseudo-Elo/accuracy/MSE summary in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68daac662478832d8e47cd03f9cedd6f